### PR TITLE
Add upload endpoint with temporary file

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ This repository contains a small Maven-based Spring Boot application that
 imports CSV data into PostgreSQL using two different approaches.
 
 - **DataExtractionApplication** – bootstraps Spring Boot.
-- **controller/DataController** – exposes `/process-data/jdbc` and
-  `/process-data/hibernate` endpoints to trigger the import.
+- **controller/DataController** – exposes `/process-data/jdbc`,
+  `/process-data/hibernate` and `/process-data/upload` endpoints to trigger the
+  import.
 - **service/DataProcessor** – calls the `insert_order` stored procedure in
   batches and logs malformed lines to `error_log.txt`.
 - **service/DataProcessorHibernate** – imports the same CSV data with JPA,
@@ -67,6 +68,18 @@ Configuration settings live in `src/main/resources/application.properties` and a
 sample dataset `data.csv` is provided in the same directory. Running the
 application requires the table, sequence, and stored procedure definitions shown
 above.
+
+### Uploading a custom CSV file
+
+You can POST a CSV directly to the application instead of relying on the bundled
+`data.csv` file:
+
+```bash
+curl -F file=@/path/to/your.csv http://localhost:8085/process-data/upload
+```
+
+The uploaded file is imported using both the stored procedure and Hibernate
+pipelines and then removed from disk when processing completes.
 
 A single test class (`DataExtractionApplicationTests`) currently verifies that
 the Spring context loads. Expanding tests and error handling would be useful

--- a/src/main/java/com/ecommerce/data_extraction/controller/DataController.java
+++ b/src/main/java/com/ecommerce/data_extraction/controller/DataController.java
@@ -5,13 +5,16 @@ import com.ecommerce.data_extraction.service.DataProcessorHibernate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.BufferedWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.StandardCopyOption;
 
 @RestController
 @RequestMapping("/process-data")
@@ -55,6 +58,37 @@ public class DataController {
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.status(500).body("❌ Import failed: " + e.getMessage());
+        }
+    }
+
+    @PostMapping("/upload")
+    public ResponseEntity<String> uploadFile(@RequestParam("file") MultipartFile file) {
+        Path tempFile = null;
+        try {
+            tempFile = Files.createTempFile("uploaded-", ".csv");
+            Files.copy(file.getInputStream(), tempFile, StandardCopyOption.REPLACE_EXISTING);
+
+            BufferedWriter errorWriter = Files.newBufferedWriter(
+                    Paths.get("../src/main/resources/error_log.txt"),
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.APPEND
+            );
+
+            dataProcessor.processWithStoredProcedure(tempFile, errorWriter);
+            dataProcessorHibernate.importCSV(tempFile);
+
+            return ResponseEntity.ok("✅ Upload import successful!");
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(500).body("❌ Import failed: " + e.getMessage());
+        } finally {
+            if (tempFile != null) {
+                try {
+                    Files.deleteIfExists(tempFile);
+                } catch (Exception ex) {
+                    ex.printStackTrace();
+                }
+            }
         }
     }
 }

--- a/src/test/java/com/ecommerce/data_extraction/DataExtractionApplicationTests.java
+++ b/src/test/java/com/ecommerce/data_extraction/DataExtractionApplicationTests.java
@@ -1,13 +1,28 @@
 package com.ecommerce.data_extraction;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
 class DataExtractionApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+        @Autowired
+        private RequestMappingHandlerMapping handlerMapping;
+
+        @Test
+        void contextLoads() {
+        }
+
+        @Test
+        void uploadEndpointMapped() {
+                boolean exists = handlerMapping.getHandlerMethods().keySet().stream()
+                        .flatMap(info -> info.getPathPatternsCondition().getPatternValues().stream())
+                        .anyMatch(p -> p.equals("/process-data/upload"));
+                assertTrue(exists, "upload endpoint mapping missing");
+        }
 
 }


### PR DESCRIPTION
## Summary
- add `/process-data/upload` endpoint for posting CSV files
- save the uploaded file to a temp location and clean up afterward
- document the new endpoint usage
- ensure the endpoint mapping exists in tests

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68705a510e44832bad9ef2d6b7daaadd